### PR TITLE
metabase docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   postgres:
     image: postgres
+    container_name: postgres
     restart: unless-stopped
     environment:
       - POSTGRES_USER=postgres
@@ -22,4 +23,12 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: sybilx@supermodular.xyz
       PGADMIN_DEFAULT_PASSWORD: admin
+    restart: unless-stopped
+  metabase:
+    image: metabase/metabase
+    container_name: metabase
+    depends_on:
+      - postgres
+    ports:
+      - 3000:3000
     restart: unless-stopped


### PR DESCRIPTION
Running `docker compose up` as usual exposes Metabase on port 3000 to the host machine:

![Screenshot 2023-08-01 at 7 30 23 PM](https://github.com/supermodularxyz/grants-etl/assets/14002941/716e03f4-79dd-4595-aa62-f8f76b1f810a)
