### PR TITLE
add example query

### DIFF
--- a/queries/circular-donations.sql
+++ b/queries/circular-donations.sql
@@ -1,0 +1,7 @@
+-- All transactions where donor is seemingly donating to themselves.
+SELECT v."transaction",
+       v.voter,
+       v."roundId",
+       v."amountUSD"
+FROM public."Vote" AS v
+WHERE v.voter = v."grantAddress";


### PR DESCRIPTION
Find transactions where the same address is both sender and recipient of donations.